### PR TITLE
Replacing Wall Clock with Monotonic Clock

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ ACLabelCountting 有 5 个基本操作分别是：
 
 ``` swift
 private func fireDisplayLink() {
-        lastUpdate = Date.timeIntervalSinceReferenceDate
+        lastUpdate = CACurrentMediaTime()
         displayLink = CADisplayLink(target: self, selector: #selector(updateNumber))
         displayLink.preferredFramesPerSecond = LabelCountingConst.countRate
         displayLink.add(to: RunLoop.main, forMode: .commonModes)

--- a/Source/ACLabelCounting.swift
+++ b/Source/ACLabelCounting.swift
@@ -33,7 +33,7 @@ class ACLabelCounting: UILabel {
     private var animationType: ACLabelCountingAnimationType = .None
     private var duration: TimeInterval = LabelCountingConst.defaultDuration
     private var displayLink: CADisplayLink! = CADisplayLink()
-    private var lastUpdate: TimeInterval = Date.timeIntervalSinceReferenceDate
+    private var lastUpdate: TimeInterval = CACurrentMediaTime()
     
     // number
     private var startValue: Double = 0
@@ -44,7 +44,7 @@ class ACLabelCounting: UILabel {
     private var attributedTextClosure: ((String) -> NSAttributedString)?
     
     @objc func updateNumber(value: TimeInterval) {
-        let now = Date.timeIntervalSinceReferenceDate
+        let now = CACurrentMediaTime()
         progress += Double(now - self.lastUpdate)
         self.lastUpdate = now
         
@@ -80,7 +80,7 @@ class ACLabelCounting: UILabel {
     }
     
     private func fireDisplayLink() {
-        lastUpdate = Date.timeIntervalSinceReferenceDate
+        lastUpdate = CACurrentMediaTime()
         displayLink = CADisplayLink(target: self, selector: #selector(updateNumber))
         if #available(iOS 10, *) {
             displayLink.preferredFramesPerSecond = LabelCountingConst.countRate
@@ -124,7 +124,7 @@ class ACLabelCounting: UILabel {
     }
     
     func restore() {
-        self.lastUpdate = Date.timeIntervalSinceReferenceDate
+        self.lastUpdate = CACurrentMediaTime()
         fireDisplayLink()
     }
     


### PR DESCRIPTION
Replacing Wall Clock with Monotonic Clock to prevent negative progress when there are leap seconds or timezone changes.

For reference, here are classic solutions for Monotonic (and reliable) time progression:
 - `mach_absolute_time()` from Darwin, but requires conversion to seconds with mach_timebase_info
 - `ProcessInfo.processInfo.systemUptime` from Foundation, open-source wrapper on mach_absolute_time() giving directly a number of seconds
 - `DispatchTime.now()` from Dispatch, open-source wrapper on mach_absolute_time() giving easily a number of seconds
 - `CACurrentMediaTime()` from QuartzCore, close-source wrapper giving directly a number of seconds, and what Apple uses for animations: https://www.google.com/search?q=CACurrentMediaTime+site%3Aopensource.apple.com

And here are classic solutions for Wall clocks (totally *unreliable*! for timing) which are affected by leap seconds, timezone changes, winter/summer hour changes, any manual user change on the system clock:
- `gettimeofday()` in POSIX standard
- `DispatchWallTime.now()` from Dispatch
- `CFAbsoluteTimeGetCurrent()` from CoreFoundation
- `Date()`/`NSDate()` from Foundation and any of its methods (including `timeIntervalSinceReferenceDate`)
